### PR TITLE
Remove comments from generated code

### DIFF
--- a/sbt4nb/src/org/netbeans/modules/sbt4nb/generators/SpringCorsCodeGenerator.java
+++ b/sbt4nb/src/org/netbeans/modules/sbt4nb/generators/SpringCorsCodeGenerator.java
@@ -42,7 +42,7 @@ public class SpringCorsCodeGenerator implements CodeGenerator {
 "    config.addAllowedMethod(\"DELETE\");\n" +
 "    config.addAllowedMethod(\"PATCH\");\n" +
 "    source.registerCorsConfiguration(\"/**\", config);\n" +
-"    // return new CorsFilter(source);\n" +
+"\n" +
 "    final FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));\n" +
 "    bean.setOrder(0);\n" +
 "    return bean;\n" +


### PR DESCRIPTION
Comments are a good idea, but not commented code, specially when it is generated code.

This specific piece of code does not explain why it is there, when would this need to be uncommented. The purpose is not clear.

Assuming this is legacy code, we should remove it. Don't want all the users carrying history.
